### PR TITLE
tr(docker): do not remove default resources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,7 @@ FROM $BONITA_BASE_IMAGE
 
 ARG CUSTOM_APPLICATION_RESOURCES_FOLDER="resources"
 ARG BONITA_CUSTOM_APPLICATION_FOLDER="my-application"
-
 ARG BONITA_WEB_INF_CLASSES_PATH="/opt/bonita/server/webapps/bonita/WEB-INF/classes"
-ARG BONITA_PAGES_PATH="${BONITA_WEB_INF_CLASSES_PATH}/org/bonitasoft/web/page"
-ARG BONITA_APPLICATIONS_PATH="${BONITA_WEB_INF_CLASSES_PATH}/org/bonitasoft/web/application"
 
 # Copy custom bonita application resources (e.g. .zip and .bconf) to the dedicated bundle folder
 COPY --chown=bonita:bonita ${CUSTOM_APPLICATION_RESOURCES_FOLDER}/* ${BONITA_WEB_INF_CLASSES_PATH}/${BONITA_CUSTOM_APPLICATION_FOLDER}/
-
-# Remove unecessary provided Bonita generic pages and applications
-RUN rm ${BONITA_PAGES_PATH}/*.zip ${BONITA_APPLICATIONS_PATH}/*.zip


### PR DESCRIPTION
In Dockerfile do not remove default Bonita provided resources (pages and applications). Same behavior as Tomcat bundle.